### PR TITLE
change cfg path ~

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "pind"
-version = "0.1.5"
+version = "0.2.1"
 dependencies = [
  "evdev",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pind"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 
 [dependencies]

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BUILD_DIR   = target/release
 INSTALL_DIR = /usr/local/bin
-CONFIG_DIR  = /etc/pind
+CONFIG_DIR  = $(HOME)/.config/pind
 
 build:
 	cargo build --release
@@ -12,8 +12,8 @@ install: build
 	sudo cp ./pindc $(INSTALL_DIR)/
 	sudo chmod 755 $(INSTALL_DIR)/pindc
 	sudo chmod 755 $(INSTALL_DIR)/pindd
-	sudo mkdir $(CONFIG_DIR)
-	sudo cp pindrc $(CONFIG_DIR)
+	mkdir -p $(CONFIG_DIR)
+	cp -n pindrc $(CONFIG_DIR)/ 2>/dev/null || true
 
 uninstall:
 	sudo rm /usr/local/bin/pindd

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ to restart it just run the command again
 it will kill the first process and run it again
 
 ## Config
-the default config path is in ```/etc/pind/pindrc```.
+the default config path is in ```~/.config/pind/pindrc```.
 check the pindrc file for more info.
 
 **Config example:**

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,11 +26,11 @@
 
 
 use evdev::{AttributeSet, Device, KeyCode, enumerate};
-use std::{env::{var,args},fs::{read_to_string,canonicalize}, path::PathBuf, process::{exit,Command, Stdio}, sync::{Arc, OnceLock}, thread};
+use std::{env::{var,args},fs::read_to_string, path::PathBuf, process::{exit,Command, Stdio}, sync::{Arc, OnceLock}, thread};
 
 const DELAY  :u64  =  25; // 25ms
-const CONFIG :&str =  "/etc/pind/pindrc"; // You can use ~/ for user path
-                                          // like ~/.config/pind/pindrc
+const CONFIG :&str = "~/.config/pind/pindrc"; // path cfg
+
 static BINDINGS: OnceLock<Arc<Vec<(AttributeSet<KeyCode>, String)>>> = OnceLock::new();
 
 fn get_bindings() -> Arc<Vec<(AttributeSet<KeyCode>, String)>>
@@ -139,8 +139,10 @@ fn keyboards() -> Vec<PathBuf>
 
 fn load_config(config: &str) -> Vec<(AttributeSet<KeyCode>, String)>
 {
-    let content = read_to_string(canonicalize(PathBuf::from(config.replace("~",&var("HOME").unwrap_or_default()))).unwrap_or_else(|e|{error("config",&e.to_string())}))
-        .unwrap_or_else(|e| error("Config file read failed", &e.to_string()));
+    let config_path = config.replace("~", &var("HOME").unwrap_or_default());
+    
+    let content = read_to_string(PathBuf::from(&config_path))
+        .unwrap_or_else(|e| error("CONFIG", &e.to_string()));
     
     content.lines()
         .filter(|line| !line.starts_with('#') && !line.trim().is_empty())

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,15 +5,14 @@
 //
 // Features:
 // - Supports modifier keys (Ctrl, Shift, Alt, Meta) and common keys.
-// - Loads key bindings from a configuration file (/etc/pind/pindrc).
+// - Loads key bindings from a configuration file (~/.config/pind/pindrc).
 // - Runs commands as a specified user using `runuser`.
 // - Detects multiple keyboards and avoids duplicates.
 // - Non-blocking key polling with a configurable delay (25ms by default).
 //
 // Usage:
-//   sudo ./pind [optional:user]   # user argument specifies which user to run commands as
-//
-// Config file format (/etc/pind/pindrc):
+//   sudo ./pindc   # automatically uses current user to run commands
+// Config file format (~/.config/pind/pindrc):
 //   # Lines starting with '#' are comments
 //   <key_combination>:<command>
 //   Example:


### PR DESCRIPTION
- Changed config location from `/etc/pind/pindrc` to `~/.config/pind/pindrc`
- Updated Makefile to install to user config directory  
- Multiple users can have different keybindings
- Simplified launch: just type `pindc` to start